### PR TITLE
Review feedback

### DIFF
--- a/src/pages/ChangePassword/changePassword.tsx
+++ b/src/pages/ChangePassword/changePassword.tsx
@@ -27,6 +27,7 @@ const ChangePasswordForm: React.FC = () => {
         },
         body: JSON.stringify({ current_password, new_password }),
       });
+      //Feedback: Enhance ErrorHandling of incorrect cuurent password that should reflect in the user interface
 
       if (!response.ok) {
         throw new Error("Password Update failed");


### PR DESCRIPTION
When changing a password, if it fails due to an incorrect current password, this should be clearly reflected in the UI to inform the user about the mistake.